### PR TITLE
Added ACL Restore, Command syntax breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.idea/
 consul-backup

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ and "go get github.com/docopt/docopt-go"
 a "go build" will generate executable named "consul-backup"
 
 ##Usage
-
+```
 consul-backup [-i IP:PORT] [-t TOKEN] [--kv] [--kvfile KVBACKUPFILE] [--acl] [--aclfile ACLBACKUPFILE] [--restore]
 consul-backup -h | --help
 consul-backup --version
-
+```
 
 ##Options
-
+```
 -h --help                          Show this screen.
 --version                          Show version.
 -i, --address=IP:PORT              The HTTP endpoint of Consul [default: 127.0.0.1:8500].
@@ -25,4 +25,5 @@ consul-backup --version
 -a, --acl                          Backup or restore ACL
 -K, --kvfile=KVBACKUPFILE          KV Backup Filename [default: kv.bkp].
 -A, --aclfile=ACLBACKUPFILE        ACL Backup Filename [default: acl.bkp].
--r, --restore                      Activate restore mode``
+-r, --restore                      Activate restore mode
+```

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ a "go build" will generate executable named "consul-backup"
 
 ##Usage
 
-  consul-backup [-i IP:PORT] [-t TOKEN] [--kv] [--kvfile KVBACKUPFILE] [--acl] [--aclfile ACLBACKUPFILE] [--restore]
-  consul-backup -h | --help
-  consul-backup --version
+consul-backup [-i IP:PORT] [-t TOKEN] [--kv] [--kvfile KVBACKUPFILE] [--acl] [--aclfile ACLBACKUPFILE] [--restore]
+consul-backup -h | --help
+consul-backup --version
 
 
 ##Options
 
-  -h --help                          Show this screen.
-  --version                          Show version.
-  -i, --address=IP:PORT              The HTTP endpoint of Consul [default: 127.0.0.1:8500].
-  -t, --token=TOKEN                  An ACL Token with proper permissions in Consul [default: ].
-  -k, --kv                           Backup or restore KV
-  -a, --acl                          Backup or restore ACL
-  -K, --kvfile=KVBACKUPFILE          KV Backup Filename [default: kv.bkp].
-  -A, --aclfile=ACLBACKUPFILE        ACL Backup Filename [default: acl.bkp].
-  -r, --restore                      Activate restore mode``
+-h --help                          Show this screen.
+--version                          Show version.
+-i, --address=IP:PORT              The HTTP endpoint of Consul [default: 127.0.0.1:8500].
+-t, --token=TOKEN                  An ACL Token with proper permissions in Consul [default: ].
+-k, --kv                           Backup or restore KV
+-a, --acl                          Backup or restore ACL
+-K, --kvfile=KVBACKUPFILE          KV Backup Filename [default: kv.bkp].
+-A, --aclfile=ACLBACKUPFILE        ACL Backup Filename [default: acl.bkp].
+-r, --restore                      Activate restore mode``

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Consul Backup and Restore tool.
+# Consul Backup and Restore tool
 
 This will use consul-api (Go library) to recursively backup and restore all your
 key/value pairs.
@@ -8,17 +8,21 @@ and "go get github.com/docopt/docopt-go"
 
 a "go build" will generate executable named "consul-backup"
 
-#
-Usage:
-  consul-backup [-i IP:PORT] [-t TOKEN] [--aclbackup] [--aclbackupfile ACLBACKUPFILE] [--restore] <filename>
+##Usage
+
+  consul-backup [-i IP:PORT] [-t TOKEN] [--kv] [--kvfile KVBACKUPFILE] [--acl] [--aclfile ACLBACKUPFILE] [--restore]
   consul-backup -h | --help
   consul-backup --version
 
-Options:
+
+##Options
+
   -h --help                          Show this screen.
   --version                          Show version.
   -i, --address=IP:PORT              The HTTP endpoint of Consul [default: 127.0.0.1:8500].
   -t, --token=TOKEN                  An ACL Token with proper permissions in Consul [default: ].
-  -a, --aclbackup                    Backup ACLs, does nothing in restore mode. ACL restore not available at this time.
-  -b, --aclbackupfile=ACLBACKUPFILE  ACL Backup Filename [default: acl.bkp].
-  -r, --restore                      Activate restore mode
+  -k, --kv                           Backup or restore KV
+  -a, --acl                          Backup or restore ACL
+  -K, --kvfile=KVBACKUPFILE          KV Backup Filename [default: kv.bkp].
+  -A, --aclfile=ACLBACKUPFILE        ACL Backup Filename [default: acl.bkp].
+  -r, --restore                      Activate restore mode``

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ Options:
   -A, --aclfile=ACLBACKUPFILE        ACL Backup Filename [default: acl.bkp].
   -r, --restore                      Activate restore mode`
 
-  arguments, _ := docopt.Parse(usage, nil, true, "consul-backup 1.0", false)
+  arguments, _ := docopt.Parse(usage, nil, true, "consul-backup 1.1", false)
   fmt.Println(arguments)
 
     if arguments["--restore"] == true {


### PR DESCRIPTION
- Added method to restore acl backups to consul
- Changed command to run either acl backup/restore only or kv backup/restore only or both