### PR TITLE
Allow keys to contain ':' too

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,16 +1,15 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
-    "sort"
-    "os"
-    "io/ioutil"
-    "strings"
+	"github.com/docopt/docopt-go"
 	"github.com/hashicorp/consul/api"
-    "github.com/docopt/docopt-go"
-    "encoding/base64"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
 )
-
 
 //type KVPair struct {
 //    Key         string
@@ -24,114 +23,116 @@ import (
 
 type ByCreateIndex api.KVPairs
 
-func (a ByCreateIndex) Len() int           { return len(a) }
-func (a ByCreateIndex) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByCreateIndex) Len() int      { return len(a) }
+func (a ByCreateIndex) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
 //Sort the KVs by createIndex
 func (a ByCreateIndex) Less(i, j int) bool { return a[i].CreateIndex < a[j].CreateIndex }
 
-
 func backup(ipaddress string, token string, outfile string) {
 
-    config := api.DefaultConfig()
-    config.Address = ipaddress
-    config.Token = token
+	config := api.DefaultConfig()
+	config.Address = ipaddress
+	config.Token = token
 
 	client, _ := api.NewClient(config)
 	kv := client.KV()
 
 	pairs, _, err := kv.List("/", nil)
-    if err != nil {
-        panic(err)
-    }
-
-    sort.Sort(ByCreateIndex(pairs))
-
-    outstring := ""
-	for _, element := range pairs {
-        encoded_value := base64.StdEncoding.EncodeToString(element.Value)
-        outstring += fmt.Sprintf("%s:%s\n", element.Key, encoded_value)
+	if err != nil {
+		panic(err)
 	}
 
-    file, err := os.Create(outfile)
-    if err != nil {
-        panic(err)
-    }
+	sort.Sort(ByCreateIndex(pairs))
 
-    if _, err := file.Write([]byte(outstring)[:]); err != nil {
-        panic(err)
-    }
+	outstring := ""
+	for _, element := range pairs {
+		encoded_value := base64.StdEncoding.EncodeToString(element.Value)
+		outstring += fmt.Sprintf("%s:%s\n", element.Key, encoded_value)
+	}
+
+	file, err := os.Create(outfile)
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := file.Write([]byte(outstring)[:]); err != nil {
+		panic(err)
+	}
 }
 
 func backupAcls(ipaddress string, token string, outfile string) {
 
-    config := api.DefaultConfig()
-    config.Address = ipaddress
-    config.Token = token
+	config := api.DefaultConfig()
+	config.Address = ipaddress
+	config.Token = token
 
 	client, _ := api.NewClient(config)
 	acl := client.ACL()
 
 	tokens, _, err := acl.List(nil)
-    if err != nil {
-            panic(err)
-        }
-    // sort.Sort(ByCreateIndex(tokens))
+	if err != nil {
+		panic(err)
+	}
+	// sort.Sort(ByCreateIndex(tokens))
 
-    outstring := ""
+	outstring := ""
 	for _, element := range tokens {
-        // outstring += fmt.Sprintf("%s:%s:%s:%s\n", element.ID, element.Name, element.Type, element.Rules)
-        outstring += fmt.Sprintf("====\nID: %s\nName: %s\nType: %s\nRules:\n%s\n", element.ID, element.Name, element.Type, element.Rules)
+		// outstring += fmt.Sprintf("%s:%s:%s:%s\n", element.ID, element.Name, element.Type, element.Rules)
+		outstring += fmt.Sprintf("====\nID: %s\nName: %s\nType: %s\nRules:\n%s\n", element.ID, element.Name, element.Type, element.Rules)
 	}
 
-    file, err := os.Create(outfile)
-    if err != nil {
-        panic(err)
-    }
+	file, err := os.Create(outfile)
+	if err != nil {
+		panic(err)
+	}
 
-    if _, err := file.Write([]byte(outstring)[:]); err != nil {
-        panic(err)
-    }
+	if _, err := file.Write([]byte(outstring)[:]); err != nil {
+		panic(err)
+	}
 }
 
 /* File needs to be in the following format:
-    KEY1:VALUE1
-    KEY2:VALUE2
+   KEY1:VALUE1
+   KEY2:VALUE2
 */
 func restore(ipaddress string, token string, infile string) {
 
-    config := api.DefaultConfig()
-    config.Address = ipaddress
-    config.Token = token
+	config := api.DefaultConfig()
+	config.Address = ipaddress
+	config.Token = token
 
-    data, err := ioutil.ReadFile(infile)
-    if err != nil {
-    	panic(err)
-    }
+	data, err := ioutil.ReadFile(infile)
+	if err != nil {
+		panic(err)
+	}
 
-    client, _ := api.NewClient(config)
-    kv := client.KV()
+	client, _ := api.NewClient(config)
+	kv := client.KV()
 
-    for _, element := range strings.Split(string(data), "\n") {
-        kvp := strings.Split(element, ":")
+	for _, element := range strings.Split(string(data), "\n") {
+		split := strings.Split(element, ":")
+		key := strings.Join(split[:len(split)-1], ":")
+		value := split[len(split)-1]
 
-        if len(kvp) > 1 {
-            decoded_value, decode_err := base64.StdEncoding.DecodeString(kvp[1])
-            if decode_err != nil {
-                panic(decode_err)
-            }
+		if key != "" {
+			decoded_value, decode_err := base64.StdEncoding.DecodeString(value)
+			if decode_err != nil {
+				panic(decode_err)
+			}
 
-            p := &api.KVPair{Key: kvp[0], Value: decoded_value}
-            _, err := kv.Put(p, nil)
-            if err != nil {
-                panic(err)
-            }
-        }
-    }
+			p := &api.KVPair{Key: key, Value: decoded_value}
+			_, err := kv.Put(p, nil)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
 }
 
 func main() {
 
-    usage := `Consul KV and ACL Backup with KV Restore tool.
+	usage := `Consul KV and ACL Backup with KV Restore tool.
 
 Usage:
   consul-backup [-i IP:PORT] [-t TOKEN] [--aclbackup] [--aclbackupfile ACLBACKUPFILE] [--restore] <filename>
@@ -147,22 +148,22 @@ Options:
   -b, --aclbackupfile=ACLBACKUPFILE  ACL Backup Filename [default: acl.bkp].
   -r, --restore                      Activate restore mode`
 
-  arguments, _ := docopt.Parse(usage, nil, true, "consul-backup 1.0", false)
-  fmt.Println(arguments)
+	arguments, _ := docopt.Parse(usage, nil, true, "consul-backup 1.0", false)
+	fmt.Println(arguments)
 
-  if arguments["--restore"] == true {
-    fmt.Println("Restore mode:")
-    fmt.Printf("Warning! This will overwrite existing kv. Press [enter] to continue; CTL-C to exit")
-    fmt.Scanln()
-    fmt.Println("Restoring KV from file: ", arguments["<filename>"].(string))
-    restore(arguments["--address"].(string), arguments["--token"].(string), arguments["<filename>"].(string))
-  } else {
-    fmt.Println("Backup mode:")
-    fmt.Println("KV store will be backed up to file: ", arguments["<filename>"].(string))
-    backup(arguments["--address"].(string), arguments["--token"].(string), arguments["<filename>"].(string))
-    if arguments["--aclbackup"] == true {
-      fmt.Println("ACL Tokens will be backed up to file: ", arguments["--aclbackupfile"].(string))
-      backupAcls(arguments["--address"].(string), arguments["--token"].(string), arguments["--aclbackupfile"].(string))
-    }
-  }
+	if arguments["--restore"] == true {
+		fmt.Println("Restore mode:")
+		fmt.Printf("Warning! This will overwrite existing kv. Press [enter] to continue; CTL-C to exit")
+		fmt.Scanln()
+		fmt.Println("Restoring KV from file: ", arguments["<filename>"].(string))
+		restore(arguments["--address"].(string), arguments["--token"].(string), arguments["<filename>"].(string))
+	} else {
+		fmt.Println("Backup mode:")
+		fmt.Println("KV store will be backed up to file: ", arguments["<filename>"].(string))
+		backup(arguments["--address"].(string), arguments["--token"].(string), arguments["<filename>"].(string))
+		if arguments["--aclbackup"] == true {
+			fmt.Println("ACL Tokens will be backed up to file: ", arguments["--aclbackupfile"].(string))
+			backupAcls(arguments["--address"].(string), arguments["--token"].(string), arguments["--aclbackupfile"].(string))
+		}
+	}
 }


### PR DESCRIPTION
Split on ':' but value is only last element of the resulting array; the
key is reconcatenated with ':'. Now keys can contain ':' themselves (as
our keys do).

Also, gofmt...
